### PR TITLE
Chart Legendコンポーネント類作成

### DIFF
--- a/src/uiParts/LegendColorPicker/index.stories.ts
+++ b/src/uiParts/LegendColorPicker/index.stories.ts
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { within } from "@storybook/testing-library";
+
+import { expect } from "@storybook/jest";
+
+import { LegendColorPicker } from ".";
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta = {
+  title: "Atom/LegendColorPicker",
+  component: LegendColorPicker,
+  tags: ["autodocs"],
+} satisfies Meta<typeof LegendColorPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
+/**
+ * colorPicker表示テスト
+ */
+export const ColorPickerDisplay: Story = {
+  args: {
+    value: "#ff0000",
+    label: "色選択",
+  },
+  play: async ({ canvasElement, initialArgs }) => {
+    const canvas = within(canvasElement);
+
+    const colorPicker = await canvas.getByLabelText(initialArgs.label);
+
+    const color_code = colorPicker.getAttribute("value");
+    expect(color_code).toBe(initialArgs.value);
+  },
+};
+
+/**
+ * colorPicker表示テスト
+ */
+export const ColorPickerClass: Story = {
+  args: {
+    ...ColorPickerDisplay.args,
+    className: "color_picker",
+  },
+  play: async ({ canvasElement, initialArgs }) => {
+    const canvas = within(canvasElement);
+
+    const colorPicker = await canvas.getByLabelText(initialArgs.label);
+
+    /// input側ではなく、labelにclassNameを付与するため上の要素を見る
+    const className = colorPicker.parentElement?.className;
+    expect(className).toBe(initialArgs.className);
+  },
+};

--- a/src/uiParts/LegendColorPicker/index.tsx
+++ b/src/uiParts/LegendColorPicker/index.tsx
@@ -3,19 +3,18 @@ type LegendColorPickerProps = {
   value: string;
   setValue: (new_value: string) => void;
   className?: string;
+  style?: React.CSSProperties;
 };
 export const LegendColorPicker: React.FC<LegendColorPickerProps> = ({
   label,
   value, // #f00 だとダメだった
   setValue,
   className,
+  style,
 }) => {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setValue(value);
-  };
-  const style = {
-    borderColor: value,
   };
 
   return (

--- a/src/uiParts/LegendColorPicker/index.tsx
+++ b/src/uiParts/LegendColorPicker/index.tsx
@@ -1,0 +1,26 @@
+type LegendColorPickerProps = {
+  label: string;
+  value: string;
+  setValue: (new_value: string) => void;
+  className?: string;
+};
+export const LegendColorPicker: React.FC<LegendColorPickerProps> = ({
+  label,
+  value, // #f00 だとダメだった
+  setValue,
+  className,
+}) => {
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setValue(value);
+  };
+  const style = {
+    borderColor: value,
+  };
+
+  return (
+    <label className={className} style={style}>
+      <input type="color" value={value} onChange={onChange} /> {label}
+    </label>
+  );
+};

--- a/src/uiParts/LegendColorPickerList/index.stories.ts
+++ b/src/uiParts/LegendColorPickerList/index.stories.ts
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { within } from "@storybook/testing-library";
+
+import { expect } from "@storybook/jest";
+
+import { LegendColorPickerList } from ".";
+import style from "./style.module.css";
+import { LegendColorPickerArg } from "./setting_stories";
+//import { LABELS, CheckboxListArgs, hasLabel } from "./setting_stories";
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta = {
+  title: "Molecule/LegendColorPickerList",
+  component: LegendColorPickerList,
+  tags: ["autodocs"],
+} satisfies Meta<typeof LegendColorPickerList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
+
+const legendDatum = LegendColorPickerArg.legendData[0];
+/**
+ * データ数だけ colorPickerが存在するかテスト
+ */
+export const ColorPickerElementCount: Story = {
+  args: {
+    legendData: [
+      /// テストしやすいよう、label名を揃える
+      legendDatum,
+      legendDatum,
+      legendDatum,
+    ],
+  },
+  play: async ({ canvasElement, initialArgs }) => {
+    const canvas = within(canvasElement);
+
+    const color_picker_count = await canvas.getAllByLabelText(legendDatum.label)
+      .length;
+    expect(color_picker_count).toBe(initialArgs.legendData.length);
+  },
+};
+
+/**
+ * style.moduleで設定したclass名が ColorPickerに反映されているかテスト
+ */
+export const ColorPickerClassName: Story = {
+  args: {
+    ...LegendColorPickerArg,
+  },
+  play: async ({ canvasElement, initialArgs }) => {
+    const canvas = within(canvasElement);
+
+    for (const { label } of initialArgs.legendData) {
+      const color_picker = await canvas.findByLabelText(label);
+
+      /// inputの親、labelにクラス名を付与している
+      const className = color_picker.parentElement?.className;
+      expect(className).toBe(style.legend_color_picker);
+    }
+  },
+};
+
+/**
+ * 表示例（色を変更後、他の例に移動することでpropsの色が変更している
+ */
+export const LegendColorPickerListExample: Story = {
+  args: {
+    ...LegendColorPickerArg,
+  },
+};

--- a/src/uiParts/LegendColorPickerList/index.tsx
+++ b/src/uiParts/LegendColorPickerList/index.tsx
@@ -1,0 +1,36 @@
+import { LegendColorPicker } from "../LegendColorPicker";
+import style from "./style.module.css";
+import { LegendInfo } from "./type";
+
+type LegendColorPickerListProps = {
+  legendData: LegendInfo[];
+  setColorCodeForLabel: (label: string, color_code: string) => void;
+};
+export const LegendColorPickerList: React.FC<LegendColorPickerListProps> = ({
+  legendData,
+  setColorCodeForLabel,
+}) => {
+  const createSetValue = (label: string) => {
+    return (color_code: string) => {
+      setColorCodeForLabel(label, color_code);
+    };
+  };
+
+  return (
+    <>
+      {legendData.map(({ label, value }) => {
+        const setValue = createSetValue(label);
+
+        return (
+          <LegendColorPicker
+            className={style.legend_color_picker}
+            key={label}
+            label={label}
+            value={value}
+            setValue={setValue}
+          />
+        );
+      })}
+    </>
+  );
+};

--- a/src/uiParts/LegendColorPickerList/index.tsx
+++ b/src/uiParts/LegendColorPickerList/index.tsx
@@ -10,6 +10,9 @@ export const LegendColorPickerList: React.FC<LegendColorPickerListProps> = ({
   legendData,
   setColorCodeForLabel,
 }) => {
+  const createStyle = (value: string): React.CSSProperties => ({
+    borderColor: value,
+  });
   const createSetValue = (label: string) => {
     return (color_code: string) => {
       setColorCodeForLabel(label, color_code);
@@ -19,11 +22,13 @@ export const LegendColorPickerList: React.FC<LegendColorPickerListProps> = ({
   return (
     <>
       {legendData.map(({ label, value }) => {
+        const colorPickerStyle = createStyle(value);
         const setValue = createSetValue(label);
 
         return (
           <LegendColorPicker
             className={style.legend_color_picker}
+            style={colorPickerStyle}
             key={label}
             label={label}
             value={value}

--- a/src/uiParts/LegendColorPickerList/setting_stories.ts
+++ b/src/uiParts/LegendColorPickerList/setting_stories.ts
@@ -1,0 +1,16 @@
+const findLabelIndex = (label: string) =>
+  LegendColorPickerArg.legendData.findIndex((elem) => elem.label === label);
+
+export const LegendColorPickerArg = {
+  legendData: [
+    { label: "ラベル1", value: "#ff0000" },
+    { label: "ラベル2", value: "#00ff00" },
+    { label: "ラベル3", value: "#0000ff" },
+  ],
+  setColorCodeForLabel: (label: string, color_code: string) => {
+    const index = findLabelIndex(label);
+    if (index === -1) return;
+
+    LegendColorPickerArg.legendData[index].value = color_code;
+  },
+};

--- a/src/uiParts/LegendColorPickerList/style.module.css
+++ b/src/uiParts/LegendColorPickerList/style.module.css
@@ -1,0 +1,5 @@
+.legend_color_picker {
+    border-bottom: solid;
+    border-width: 4px;
+    margin: 0px 4px 2px;
+}

--- a/src/uiParts/LegendColorPickerList/type.ts
+++ b/src/uiParts/LegendColorPickerList/type.ts
@@ -1,0 +1,4 @@
+export type LegendInfo = {
+  label: string;
+  value: string;
+};


### PR DESCRIPTION
グラフのLegend兼、グラフの色を選択する機能。

ランダム(or 任意で47個）の色を決めるより、最終的にユーザ側で色を指定できる方がユーザビリティに良いと判断したため作成。